### PR TITLE
Update util.py

### DIFF
--- a/libpysal/weights/util.py
+++ b/libpysal/weights/util.py
@@ -1082,8 +1082,9 @@ def get_points_array_from_shapefile(shapefile):
 
     Parameters
     ----------
-    shapefile     : string
-                    name of a shape file including suffix
+    shapefile     : string/geopandas.GeoSeries/geopandas.GeoDataFrame
+                    If a string, it must be a full pathname of 
+                    a shape file - including suffix
 
     Returns
     -------
@@ -1117,8 +1118,12 @@ def get_points_array_from_shapefile(shapefile):
            [ 8.33265837, 14.03162401],
            [ 9.01226541, 13.81971908]])
     """
-
-    f = psopen(shapefile)
+    if isinstance(shapefile, str):
+        f = psopen(shapefile)
+    elif isinstance(shapefile, gpd.GeoDataFrame):
+        f = shapefile['geometry']
+    elif isinstance(shapefile, gpd.GeoSeries):
+        f = shapefile
     data = get_points_array(f)
     return data
 


### PR DESCRIPTION
The get_points_array_from_shapefile function was updated so to support its applicability to a geopandas GeoDataFrame or a geopandas.GeoSeries object directly.

Hello! Please make sure to check all these boxes before submitting a Pull Request
(PR). Once you have checked the boxes, feel free to remove all text except the
justification in point 5. 

1. [x] You have run tests on this submission locally using `pytest` on your changes. Continuous integration will be run on all PRs with [GitHub Actions](https://github.com/pysal/libpysal/blob/master/.github/workflows/unittests.yml), but it is good practice to test changes locally prior to a making a PR.
2. [x] This pull request is directed to the `pysal/master` branch.
3. [x] This pull introduces new functionality covered by
   [docstrings](https://en.wikipedia.org/wiki/Docstring#Python) and
   [unittests](https://docs.python.org/2/library/unittest.html)? 
4. [x] You have [assigned a
   reviewer](https://help.github.com/articles/assigning-issues-and-pull-requests-to-other-github-users/) and added relevant [labels](https://help.github.com/articles/applying-labels-to-issues-and-pull-requests/)
5. [x] The justification for this PR is: Prior to this Pull Request, the function libpysal.weights.min_threshold_dist_from_shapefile would not support a geopandas GeoDataFrame or a Geopandas.GeoSeries object directly; it would only support a string pointing towards a given file (.shp) within one's computer. In this respect, I have updated this function so to support these objects directly; this Pull Request updated this function so to ensure its elder behavior, of working with a string (filepath of the .shp).
